### PR TITLE
Unpaged findAll()

### DIFF
--- a/src/main/java/th/co/geniustree/springdata/jpa/repository/JpaSpecificationExecutorWithProjection.java
+++ b/src/main/java/th/co/geniustree/springdata/jpa/repository/JpaSpecificationExecutorWithProjection.java
@@ -1,13 +1,14 @@
 package th.co.geniustree.springdata.jpa.repository;
 
-import java.io.Serializable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.query.JpaEntityGraph;
 import org.springframework.data.repository.NoRepositoryBean;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -17,13 +18,18 @@ import java.util.Optional;
 public interface JpaSpecificationExecutorWithProjection<T, ID> {
 
     <R> Optional<R> findById(ID id, Class<R> projectionClass);
-  
+
     <R> Optional<R> findOne(Specification<T> spec, Class<R> projectionClass);
+
+    <R> List<R> findAll(Specification<T> spec, Class<R> projectionClass);
+
+    <R> List<R> findAll(Specification<T> spec, Class<R> projectionClass, Sort sort);
 
     <R> Page<R> findAll(Specification<T> spec, Class<R> projectionClass, Pageable pageable);
 
     /**
      * Use Spring Data Annotation instead of manually provide EntityGraph.
+     *
      * @param spec
      * @param projectionType
      * @param namedEntityGraph
@@ -37,6 +43,7 @@ public interface JpaSpecificationExecutorWithProjection<T, ID> {
 
     /**
      * Use Spring Data Annotation instead of manually provide EntityGraph.
+     *
      * @param spec
      * @param projectionClass
      * @param dynamicEntityGraph

--- a/src/main/java/th/co/geniustree/springdata/jpa/repository/support/JpaSpecificationExecutorWithProjectionImpl.java
+++ b/src/main/java/th/co/geniustree/springdata/jpa/repository/support/JpaSpecificationExecutorWithProjectionImpl.java
@@ -24,8 +24,25 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import th.co.geniustree.springdata.jpa.repository.JpaSpecificationExecutorWithProjection;
 
-import javax.persistence.*;
-import javax.persistence.criteria.*;
+import javax.persistence.EntityManager;
+import javax.persistence.LockModeType;
+import javax.persistence.ManyToOne;
+import javax.persistence.NoResultException;
+import javax.persistence.OneToOne;
+import javax.persistence.Query;
+import javax.persistence.Tuple;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Fetch;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.JoinType;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Selection;
 import javax.persistence.metamodel.Attribute;
 import javax.persistence.metamodel.Bindable;
 import javax.persistence.metamodel.ManagedType;
@@ -34,9 +51,19 @@ import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Member;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
-import static javax.persistence.metamodel.Attribute.PersistentAttributeType.*;
+import static javax.persistence.metamodel.Attribute.PersistentAttributeType.ELEMENT_COLLECTION;
+import static javax.persistence.metamodel.Attribute.PersistentAttributeType.MANY_TO_MANY;
+import static javax.persistence.metamodel.Attribute.PersistentAttributeType.MANY_TO_ONE;
+import static javax.persistence.metamodel.Attribute.PersistentAttributeType.ONE_TO_MANY;
+import static javax.persistence.metamodel.Attribute.PersistentAttributeType.ONE_TO_ONE;
 
 
 /**
@@ -46,7 +73,8 @@ public class JpaSpecificationExecutorWithProjectionImpl<T, ID extends Serializab
 
     private static final Logger log = LoggerFactory.getLogger(JpaSpecificationExecutorWithProjectionImpl.class);
     private static final Map<Attribute.PersistentAttributeType, Class<? extends Annotation>> ASSOCIATION_TYPES;
-    static{
+
+    static {
         Map<Attribute.PersistentAttributeType, Class<? extends Annotation>> persistentAttributeTypes = new HashMap<Attribute.PersistentAttributeType, Class<? extends Annotation>>();
         persistentAttributeTypes.put(ONE_TO_ONE, OneToOne.class);
         persistentAttributeTypes.put(ONE_TO_MANY, null);
@@ -56,6 +84,7 @@ public class JpaSpecificationExecutorWithProjectionImpl<T, ID extends Serializab
 
         ASSOCIATION_TYPES = Collections.unmodifiableMap(persistentAttributeTypes);
     }
+
     private final EntityManager entityManager;
 
     private final ProjectionFactory projectionFactory = new SpelAwareProxyProjectionFactory();
@@ -67,11 +96,11 @@ public class JpaSpecificationExecutorWithProjectionImpl<T, ID extends Serializab
         this.entityManager = entityManager;
         this.entityInformation = entityInformation;
     }
-    
+
     @Override
     public <R> Optional<R> findById(ID id, Class<R> projectionType) {
         final ReturnedType returnedType = ReturnTypeWarpper.of(projectionType, getDomainClass(), projectionFactory);
-        
+
         CriteriaBuilder builder = this.entityManager.getCriteriaBuilder();
         CriteriaQuery<Tuple> q = builder.createQuery(Tuple.class);
         Root<T> root = q.from(getDomainClass());
@@ -89,11 +118,11 @@ public class JpaSpecificationExecutorWithProjectionImpl<T, ID extends Serializab
         } else {
             throw new IllegalArgumentException("only except projection");
         }
-        
+
         final TypedQuery<Tuple> query = this.applyRepositoryMethodMetadata(this.entityManager.createQuery(q));
-        
+
         try {
-            final MyResultProcessor resultProcessor = new MyResultProcessor(projectionFactory,returnedType);
+            final MyResultProcessor resultProcessor = new MyResultProcessor(projectionFactory, returnedType);
             final R singleResult = resultProcessor.processResult(query.getSingleResult(), new TupleConverter(returnedType));
             return Optional.ofNullable(singleResult);
         } catch (NoResultException e) {
@@ -107,7 +136,7 @@ public class JpaSpecificationExecutorWithProjectionImpl<T, ID extends Serializab
         final ReturnedType returnedType = ReturnTypeWarpper.of(projectionType, getDomainClass(), projectionFactory);
         final TypedQuery<Tuple> query = getTupleQuery(spec, Sort.unsorted(), returnedType);
         try {
-            final MyResultProcessor resultProcessor = new MyResultProcessor(projectionFactory,returnedType);
+            final MyResultProcessor resultProcessor = new MyResultProcessor(projectionFactory, returnedType);
             final R singleResult = resultProcessor.processResult(query.getSingleResult(), new TupleConverter(returnedType));
             return Optional.ofNullable(singleResult);
         } catch (NoResultException e) {
@@ -116,12 +145,27 @@ public class JpaSpecificationExecutorWithProjectionImpl<T, ID extends Serializab
     }
 
     @Override
+    public <R> List<R> findAll(Specification<T> spec, Class<R> projectionType) {
+        return findAll(spec, projectionType, Sort.unsorted());
+    }
+
+    @Override
+    public <R> List<R> findAll(Specification<T> spec, Class<R> projectionType, Sort sort) {
+        return findAll(spec, projectionType, Pageable.unpaged(), sort).getContent();
+    }
+
+    @Override
     public <R> Page<R> findAll(Specification<T> spec, Class<R> projectionType, Pageable pageable) {
+        Sort sort = pageable.getSort() != null && pageable.getSort().isSorted() ? pageable.getSort() : Sort.unsorted();
+        return findAll(spec, projectionType, pageable, sort);
+    }
+
+    private <R> Page<R> findAll(Specification<T> spec, Class<R> projectionType, Pageable pageable, Sort sort) {
         final ReturnedType returnedType = ReturnTypeWarpper.of(projectionType, getDomainClass(), projectionFactory);
-        final TypedQuery<Tuple> query = getTupleQuery(spec, pageable.getSort() != null && pageable.getSort().isSorted() ? pageable.getSort() : Sort.unsorted(), returnedType);
-        final MyResultProcessor resultProcessor = new MyResultProcessor(projectionFactory,returnedType);
+        final TypedQuery<Tuple> query = getTupleQuery(spec, sort, returnedType);
+        final MyResultProcessor resultProcessor = new MyResultProcessor(projectionFactory, returnedType);
         if (pageable.isPaged()) {
-            query.setFirstResult((int)pageable.getOffset());
+            query.setFirstResult((int) pageable.getOffset());
             query.setMaxResults(pageable.getPageSize());
         }
         final List<R> resultList = resultProcessor.processResult(query.getResultList(), new TupleConverter(returnedType));
@@ -135,8 +179,8 @@ public class JpaSpecificationExecutorWithProjectionImpl<T, ID extends Serializab
         Long total = 0L;
 
         Long element;
-        for(Iterator var3 = totals.iterator(); var3.hasNext(); total = total + (element == null ? 0L : element)) {
-            element = (Long)var3.next();
+        for (Iterator var3 = totals.iterator(); var3.hasNext(); total = total + (element == null ? 0L : element)) {
+            element = (Long) var3.next();
         }
 
         return total;
@@ -144,17 +188,17 @@ public class JpaSpecificationExecutorWithProjectionImpl<T, ID extends Serializab
 
     @Override
     public <R> Page<R> findAll(Specification<T> spec, Class<R> projectionType, String namedEntityGraph, org.springframework.data.jpa.repository.EntityGraph.EntityGraphType type, Pageable pageable) {
-        return findAll(spec,projectionType,pageable);
+        return findAll(spec, projectionType, pageable);
     }
 
     @Override
     public <R> Page<R> findAll(Specification<T> spec, Class<R> projectionType, JpaEntityGraph dynamicEntityGraph, Pageable pageable) {
-        return findAll(spec,projectionType,pageable);
+        return findAll(spec, projectionType, pageable);
     }
 
     protected TypedQuery<Tuple> getTupleQuery(@Nullable Specification spec, Sort sort, ReturnedType returnedType) {
-        if (!returnedType.needsCustomConstruction()){
-            return getQuery(spec,sort);
+        if (!returnedType.needsCustomConstruction()) {
+            return getQuery(spec, sort);
         }
         CriteriaBuilder builder = this.entityManager.getCriteriaBuilder();
         CriteriaQuery<Tuple> query = builder.createQuery(Tuple.class);
@@ -213,9 +257,10 @@ public class JpaSpecificationExecutorWithProjectionImpl<T, ID extends Serializab
 
         return toReturn;
     }
+
     private void applyQueryHints(Query query) {
         QueryHints queryHints = DefaultQueryHints.of(this.entityInformation, getRepositoryMethodMetadata());
-        if(queryHints==null){
+        if (queryHints == null) {
             queryHints = QueryHints.NoHints.INSTANCE;
         }
         for (Map.Entry<String, Object> hint : queryHints.withFetchGraphs(this.entityManager)) {
@@ -311,6 +356,7 @@ public class JpaSpecificationExecutorWithProjectionImpl<T, ID extends Serializab
 
         return from.join(attribute, JoinType.LEFT);
     }
+
     private static boolean isAlreadyFetched(From<?, ?> from, String attribute) {
 
         for (Fetch<?, ?> fetch : from.getFetches()) {

--- a/src/test/java/th/co/geniustree/springdata/jpa/SpecificationExecutorProjectionTest.java
+++ b/src/test/java/th/co/geniustree/springdata/jpa/SpecificationExecutorProjectionTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +16,7 @@ import th.co.geniustree.springdata.jpa.domain.Document;
 import th.co.geniustree.springdata.jpa.repository.DocumentRepository;
 import th.co.geniustree.springdata.jpa.specification.DocumentSpecs;
 
+import java.util.List;
 import java.util.Optional;
 
 @RunWith(SpringRunner.class)
@@ -22,62 +24,170 @@ import java.util.Optional;
 @DataJpaTest
 @Transactional
 public class SpecificationExecutorProjectionTest {
+
     @Autowired
     private DocumentRepository documentRepository;
-
 
     @Test
     public void findAll() {
         Specification<Document> where = Specification.where(DocumentSpecs.idEq(1L));
-        Page<DocumentRepository.DocumentWithoutParent> all = documentRepository.findAll(where, DocumentRepository.DocumentWithoutParent.class, PageRequest.of(0,10));
+
+        Page<DocumentRepository.DocumentWithoutParent> all = documentRepository.findAll(
+                where, DocumentRepository.DocumentWithoutParent.class, PageRequest.of(0, 10)
+        );
         Assertions.assertThat(all).isNotEmpty();
         Assertions.assertThat(all.getContent().get(0).getDocumentType()).isEqualTo("ต้นฉบับ");
+
+        List<DocumentRepository.DocumentWithoutParent> allList = documentRepository.findAll(
+                where, DocumentRepository.DocumentWithoutParent.class
+        );
+        Assertions.assertThat(allList).isNotEmpty();
+        Assertions.assertThat(allList.get(0).getDocumentType()).isEqualTo("ต้นฉบับ");
+
+        Sort sortByDescription = Sort.by(Sort.Order.desc("description"));
+        List<DocumentRepository.DocumentWithoutParent> allListSorted = documentRepository.findAll(
+                where, DocumentRepository.DocumentWithoutParent.class, sortByDescription
+        );
+        Assertions.assertThat(allListSorted).isNotEmpty();
+        Assertions.assertThat(allListSorted.get(0).getDocumentType()).isEqualTo("ต้นฉบับ");
     }
 
     @Test
     public void findAll2() {
         Specification<Document> where = Specification.where(DocumentSpecs.idEq(1L));
-        Page<DocumentRepository.DocumentWithoutParent> all = documentRepository.findAll(where, DocumentRepository.DocumentWithoutParent.class, PageRequest.of(0,10));
+
+        Page<DocumentRepository.DocumentWithoutParent> all = documentRepository.findAll(
+                where, DocumentRepository.DocumentWithoutParent.class, PageRequest.of(0, 10)
+        );
         Assertions.assertThat(all).isNotEmpty();
         Assertions.assertThat(all.getContent().get(0).getChild().size()).isEqualTo(1);
+
+        List<DocumentRepository.DocumentWithoutParent> allList = documentRepository.findAll(
+                where, DocumentRepository.DocumentWithoutParent.class
+        );
+        Assertions.assertThat(allList).isNotEmpty();
+        Assertions.assertThat(allList.get(0).getChild().size()).isEqualTo(1);
+
+        Sort sortByDescription = Sort.by(Sort.Order.desc("description"));
+        List<DocumentRepository.DocumentWithoutParent> allListSorted = documentRepository.findAll(
+                where, DocumentRepository.DocumentWithoutParent.class, sortByDescription
+        );
+        Assertions.assertThat(allListSorted).isNotEmpty();
+        Assertions.assertThat(allListSorted.get(0).getChild().size()).isEqualTo(1);
     }
 
     @Test
     public void findAll3() {
         Specification<Document> where = Specification.where(DocumentSpecs.idEq(1L));
-        Page<DocumentRepository.OnlyId> all = documentRepository.findAll(where, DocumentRepository.OnlyId.class, PageRequest.of(0,10));
+
+        Page<DocumentRepository.OnlyId> all = documentRepository.findAll(
+                where, DocumentRepository.OnlyId.class, PageRequest.of(0, 10)
+        );
         Assertions.assertThat(all).isNotEmpty();
         Assertions.assertThat(all.getContent().get(0).getId()).isEqualTo(1L);
+
+        List<DocumentRepository.OnlyId> allList = documentRepository.findAll(
+                where, DocumentRepository.OnlyId.class
+        );
+        Assertions.assertThat(allList).isNotEmpty();
+        Assertions.assertThat(allList.get(0).getId()).isEqualTo(1L);
+
+        Sort sortByDescription = Sort.by(Sort.Order.desc("description"));
+        List<DocumentRepository.OnlyId> allListSorted = documentRepository.findAll(
+                where, DocumentRepository.OnlyId.class, sortByDescription
+        );
+        Assertions.assertThat(allListSorted).isNotEmpty();
+        Assertions.assertThat(allListSorted.get(0).getId()).isEqualTo(1L);
     }
 
     @Test
     public void findAll4() {
         Specification<Document> where = Specification.where(DocumentSpecs.idEq(24L));
-        Page<DocumentRepository.DocumentWithoutParent> all = documentRepository.findAll(where, DocumentRepository.DocumentWithoutParent.class, PageRequest.of(0,10));
+
+        Page<DocumentRepository.DocumentWithoutParent> all = documentRepository.findAll(
+                where, DocumentRepository.DocumentWithoutParent.class, PageRequest.of(0, 10)
+        );
         Assertions.assertThat(all).isNotEmpty();
         Assertions.assertThat(all.getContent().get(0).getChild()).isNull();
+
+        List<DocumentRepository.DocumentWithoutParent> allList = documentRepository.findAll(
+                where, DocumentRepository.DocumentWithoutParent.class
+        );
+        Assertions.assertThat(allList).isNotEmpty();
+        Assertions.assertThat(allList.get(0).getChild()).isNull();
+
+        Sort sortByDescription = Sort.by(Sort.Order.desc("description"));
+        List<DocumentRepository.DocumentWithoutParent> allListSorted = documentRepository.findAll(
+                where, DocumentRepository.DocumentWithoutParent.class, sortByDescription
+        );
+        Assertions.assertThat(allListSorted).isNotEmpty();
+        Assertions.assertThat(allListSorted.get(0).getChild()).isNull();
     }
 
     @Test
     public void findAll5() {
         Specification<Document> where = Specification.where(DocumentSpecs.idEq(24L));
-        Page<DocumentRepository.OnlyParent> all = documentRepository.findAll(where, DocumentRepository.OnlyParent.class, PageRequest.of(0,10));
+
+        Page<DocumentRepository.OnlyParent> all = documentRepository.findAll(
+                where, DocumentRepository.OnlyParent.class, PageRequest.of(0, 10)
+        );
         Assertions.assertThat(all).isNotEmpty();
         Assertions.assertThat(all.getContent().get(0).getParent().getId()).isEqualTo(13L);
+
+        List<DocumentRepository.OnlyParent> allList = documentRepository.findAll(
+                where, DocumentRepository.OnlyParent.class
+        );
+        Assertions.assertThat(allList).isNotEmpty();
+        Assertions.assertThat(allList.get(0).getParent().getId()).isEqualTo(13L);
+
+        Sort sortByDescription = Sort.by(Sort.Order.desc("description"));
+        List<DocumentRepository.OnlyParent> allListSorted = documentRepository.findAll(
+                where, DocumentRepository.OnlyParent.class, sortByDescription
+        );
+        Assertions.assertThat(allListSorted).isNotEmpty();
+        Assertions.assertThat(allListSorted.get(0).getParent().getId()).isEqualTo(13L);
     }
+
     @Test
-    public void find_single_page() {
+    public void findAllListUnsorted() {
+        Specification<Document> where = Specification.where(DocumentSpecs.descriptionLike("description1%"));
+
+        List<DocumentRepository.DocumentWithoutChild> all = documentRepository.findAll(
+                where, DocumentRepository.DocumentWithoutChild.class
+        );
+        Assertions.assertThat(all)
+                .hasSize(3)
+                .extracting("description")
+                .containsExactlyInAnyOrder("description10", "description11", "description12");
+    }
+
+    @Test
+    public void findAllListSorted() {
+        Specification<Document> where = Specification.where(DocumentSpecs.descriptionLike("description1%"));
+
+        Sort sortByDescription = Sort.by(Sort.Order.desc("description"));
+        List<DocumentRepository.DocumentWithoutChild> all = documentRepository.findAll(
+                where, DocumentRepository.DocumentWithoutChild.class, sortByDescription
+        );
+        Assertions.assertThat(all)
+                .hasSize(3)
+                .extracting("description")
+                .containsExactly("description12", "description11", "description10");
+    }
+
+    @Test
+    public void findSinglePage() {
         Specification<Document> where = Specification.where(DocumentSpecs.idEq(24L));
-        Page<DocumentRepository.OnlyParent> all = documentRepository.findAll(where, DocumentRepository.OnlyParent.class, PageRequest.of(0,10));
+        Page<DocumentRepository.OnlyParent> all = documentRepository.findAll(where, DocumentRepository.OnlyParent.class, PageRequest.of(0, 10));
         Assertions.assertThat(all).isNotEmpty();
         Assertions.assertThat(all.getTotalElements()).isEqualTo(1);
         Assertions.assertThat(all.getTotalPages()).isEqualTo(1);
     }
 
     @Test
-    public void find_all_page() {
+    public void findAllPage() {
         Specification<Document> where = Specification.where(null);
-        Page<DocumentRepository.OnlyParent> all = documentRepository.findAll(where, DocumentRepository.OnlyParent.class, PageRequest.of(0,10));
+        Page<DocumentRepository.OnlyParent> all = documentRepository.findAll(where, DocumentRepository.OnlyParent.class, PageRequest.of(0, 10));
         Assertions.assertThat(all).isNotEmpty();
         Assertions.assertThat(all.getTotalElements()).isEqualTo(24);
         Assertions.assertThat(all.getTotalPages()).isEqualTo(3);
@@ -89,13 +199,13 @@ public class SpecificationExecutorProjectionTest {
         Optional<DocumentRepository.DocumentWithoutParent> one = documentRepository.findOne(where, DocumentRepository.DocumentWithoutParent.class);
         Assertions.assertThat(one.get().getDocumentType()).isEqualTo("ต้นฉบับ");
     }
-    
+
     @Test
     public void findBydId() {
         Optional<DocumentRepository.DocumentWithoutParent> one = documentRepository.findById(1L, DocumentRepository.DocumentWithoutParent.class);
         Assertions.assertThat(one.get().getDocumentType()).isEqualTo("ต้นฉบับ");
     }
-    
+
     @Test
     public void findOneWithOpenProjection() {
         Specification<Document> where = Specification.where(DocumentSpecs.idEq(1L));
@@ -106,7 +216,7 @@ public class SpecificationExecutorProjectionTest {
     @Test
     public void findAllWithOpenProjection() {
         Specification<Document> where = Specification.where(DocumentSpecs.idEq(1L));
-        Page<DocumentRepository.OpenProjection> page = documentRepository.findAll(where, DocumentRepository.OpenProjection.class,PageRequest.of(0,10));
+        Page<DocumentRepository.OpenProjection> page = documentRepository.findAll(where, DocumentRepository.OpenProjection.class, PageRequest.of(0, 10));
         Assertions.assertThat(page.getContent().get(0).getDescriptionString()).isEqualTo("descriptiontest");
     }
 

--- a/src/test/java/th/co/geniustree/springdata/jpa/repository/DocumentRepository.java
+++ b/src/test/java/th/co/geniustree/springdata/jpa/repository/DocumentRepository.java
@@ -10,25 +10,35 @@ import java.util.List;
  * Created by pramoth on 9/28/2016 AD.
  */
 public interface DocumentRepository extends JpaRepository<Document,Long>,JpaSpecificationExecutorWithProjection<Document, Long> {
-    public List<DocumentWithoutParent> findByParentIsNull();
 
-    public static interface DocumentWithoutParent{
+    List<DocumentWithoutParent> findByParentIsNull();
+
+    interface DocumentWithoutParent{
         Long getId();
         String getDescription();
         String getDocumentType();
         String getDocumentCategory();
         List<DocumentWithoutParent> getChild();
     }
-    public static interface OnlyId{
+
+    interface DocumentWithoutChild{
+        Long getId();
+        String getDescription();
+        String getDocumentType();
+        String getDocumentCategory();
+    }
+
+    interface OnlyId{
         Long getId();
     }
 
-    public static interface OnlyParent extends OnlyId{
+    interface OnlyParent extends OnlyId{
         OnlyId getParent();
     }
 
-    public static interface OpenProjection extends OnlyId{
+    interface OpenProjection extends OnlyId{
         @Value("#{target.description}")
         String getDescriptionString();
     }
+
 }

--- a/src/test/java/th/co/geniustree/springdata/jpa/specification/DocumentSpecs.java
+++ b/src/test/java/th/co/geniustree/springdata/jpa/specification/DocumentSpecs.java
@@ -8,7 +8,13 @@ import th.co.geniustree.springdata.jpa.domain.Document_;
  * Created by pramoth on 9/29/2016 AD.
  */
 public class DocumentSpecs {
-    public static Specification<Document> idEq(Long id){
-        return (root, query, cb) -> cb.equal(root.get(Document_.id),id);
+
+    public static Specification<Document> idEq(Long id) {
+        return (root, query, cb) -> cb.equal(root.get(Document_.id), id);
     }
+
+    public static Specification<Document> descriptionLike(String descriptionLike) {
+        return (root, query, cb) -> cb.like(root.get(Document_.description), descriptionLike);
+    }
+
 }


### PR DESCRIPTION
Added two unpaged findAll methods
```java
<R> List<R> findAll(Specification<T> spec, Class<R> projectionClass);

<R> List<R> findAll(Specification<T> spec, Class<R> projectionClass, Sort sort);
```
The first method can be emulated by using an existing paged `findAll()` method with `Pageable.unpaged()`. But it is not an obvious solution.

The second method much more complex to emulate, because it needs to create a new class that supports unpaged behavior with ability to provide sorting.

This pull request was inspired by @[sic-sic](https://github.com/sic-sic) changes. Many thanks to him.

Fixes https://github.com/pramoth/specification-with-projection/issues/16